### PR TITLE
Allow for cloudflare config

### DIFF
--- a/src/TargetPay.php
+++ b/src/TargetPay.php
@@ -268,7 +268,7 @@ class TargetPay
      * @return ip
      */
     private function getIp() {
-        return isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : "101.10.10.02";
+        return isset($_SERVER['HTTP_CF_CONNECTING_IP']) ? $_SERVER['HTTP_CF_CONNECTING_IP'] : isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : "101.10.10.02";
     }
     
     /**


### PR DESCRIPTION
Cloudflare is very popular, seems like this should be standard - better would be to have a setter method for IP (perhaps generate one if left null for backwards compatability) like almost every other payment gateways API